### PR TITLE
Discovery on nested dtype numpy arrays and cleanup

### DIFF
--- a/datashape/coretypes.py
+++ b/datashape/coretypes.py
@@ -1260,6 +1260,13 @@ def free(ds):
         return []
 
 
+def print_unicode_string(s):
+    try:
+        return s.decode('unicode_escape').encode('ascii')
+    except AttributeError:
+        return s
+
+
 def pprint(ds, width=80):
     """ Pretty print a datashape
 
@@ -1301,8 +1308,7 @@ def pprint(ds, width=80):
 
     if isinstance(ds, Record):
         pairs = ['%s: %s' % (name if ' ' not in name else
-                             repr(name.decode('unicode_escape').encode(
-                                  'ascii')),
+                             repr(print_unicode_string(name)),
                              pprint(typ, width - len(result) - len(name)))
                  for name, typ in zip(ds.names, ds.types)]
         short = '{%s}' % ', '.join(pairs)

--- a/datashape/coretypes.py
+++ b/datashape/coretypes.py
@@ -7,10 +7,8 @@ shape and data type.
 """
 
 import ctypes
-import datetime
 import operator
 from math import ceil
-import re
 
 import numpy as np
 
@@ -91,9 +89,6 @@ class Mono(object):
     def __getitem__(self, key):
         lst = [self]
         return lst[key]
-
-    def __ne__(self, other):
-        return not (self == other)
 
     def __repr__(self):
         return '%s(%s)' % (type(self).__name__,
@@ -501,7 +496,6 @@ class DataShape(Mono):
 
     See Also
     --------
-
     datashape.dshape
     """
 
@@ -600,7 +594,6 @@ class DataShape(Mono):
         if isinstance(other, _inttypes):
             other = Fixed(other)
         return DataShape(other, *self)
-
 
     @property
     def subshape(self):
@@ -909,6 +902,7 @@ def _launder(x):
         return x[0]
     return x
 
+
 def _launder_key(k):
     """
 
@@ -1025,14 +1019,10 @@ class Tuple(Mono):
                          for i, typ in enumerate(self.parameters[0])])
 
 
-
 class JSON(Mono):
     """ JSON measure """
     cls = MEASURE
     __slots__ = ()
-
-    def __init__(self):
-        pass
 
     def __str__(self):
         return 'json'
@@ -1151,10 +1141,12 @@ class NotNumpyCompatible(Exception):
     """
     pass
 
+
 def to_numpy_dtype(ds):
     """ Throw away the shape information and just return the
     measure as NumPy dtype instance."""
     return to_numpy(ds.measure)[1]
+
 
 def to_numpy(ds):
     """
@@ -1170,8 +1162,6 @@ def to_numpy(ds):
 
     shape = tuple()
     dtype = None
-
-    #assert isinstance(ds, DataShape)
 
     if isinstance(ds, DataShape):
         # The datashape dimensions
@@ -1231,28 +1221,6 @@ def from_numpy(shape, dt):
         return DataShape(*tuple(map(Fixed, shape))+(measure,))
 
 
-def typeof(obj):
-    """
-    Return a datashape ctype for a python scalar.
-    """
-    if hasattr(obj, "dshape"):
-        return obj.dshape
-    elif isinstance(obj, np.ndarray):
-        return from_numpy(obj.shape, obj.dtype)
-    elif isinstance(obj, _inttypes):
-        return DataShape(int_)
-    elif isinstance(obj, float):
-        return DataShape(double)
-    elif isinstance(obj, complex):
-        return DataShape(complex128)
-    elif isinstance(obj, _strtypes):
-        return DataShape(string)
-    elif isinstance(obj, datetime.timedelta):
-        return DataShape(timedelta64)
-    elif isinstance(obj, datetime.datetime):
-        return DataShape(datetime64)
-    else:
-        return DataShape(pyobj)
 
 
 def expr_string(spine, const_args, outer=None):
@@ -1265,28 +1233,6 @@ def expr_string(spine, const_args, outer=None):
         return str(spine)
 
 
-def record_string(fields, values):
-    """ String representation of Record types
-
-    >>> record_string(['a', 'b'], [int32, float32])
-    '{ a : int32, b : float32 }'
-    """
-    body = ''
-    count = len(fields)
-
-    word_re=re.compile("[a-zA-Z_][a-zA-Z0-9_]*$")
-
-    def print_pair(k, v):
-        # If we find a troublesome non-alphanumeric character
-        # in the key, wrap the key in quotes.  Any troublesome, but
-        # non-unicode characters should be escaped now.  Unicode will be
-        # escaped later.
-        if word_re.match(k):
-            return '%s : %s' % (k, v)
-        else:
-            return "'%s' : %s" % (re.sub(r"(['\\])", r"\\\g<1>", k), v)
-
-    return '{ %s }' % ', '.join(map(print_pair, fields, values))
 
 
 def free(ds):
@@ -1302,14 +1248,6 @@ def free(ds):
         return result
     else:
         return []
-
-
-def type_constructor(ds):
-    """
-    Get the type constructor for the datashape type (Mono).
-    The type constructor indicates how types unify (see unification.py).
-    """
-    return type(ds)
 
 
 def pprint(ds, width=80):

--- a/datashape/coretypes.py
+++ b/datashape/coretypes.py
@@ -1223,8 +1223,9 @@ def from_numpy(shape, dt):
     elif dtype.kind == 'U':
         measure = String(dtype.itemsize // 4, 'U32')
     elif dtype.fields:
-        field_items = [(name, dtype.fields[name]) for name in dtype.names]
-        rec = [(a,CType.from_numpy_dtype(b[0])) for a,b in field_items]
+        fields = [(name, dtype.fields[name]) for name in dtype.names]
+        rec = [(name, from_numpy(t.shape, t.base))  # recurse into nested dtype
+               for name, (t, _) in fields]  # _ is the byte offset: ignore it
         measure = Record(rec)
     else:
         measure = CType.from_numpy_dtype(dtype)

--- a/datashape/coretypes.py
+++ b/datashape/coretypes.py
@@ -921,7 +921,13 @@ def _launder_key(k):
     return str(k)
 
 
-class Record(Mono):
+class CollectionPrinter(object):
+    def __repr__(self):
+        s = str(self)
+        return 'dshape("%s")' % s.encode('unicode_escape').decode('ascii')
+
+
+class Record(CollectionPrinter, Mono):
     """
     A composite data structure of ordered fields mapped to types.
 
@@ -989,7 +995,7 @@ class Record(Mono):
         return pprint(self)
 
 
-class Tuple(Mono):
+class Tuple(CollectionPrinter, Mono):
     """
     A product type.
     """

--- a/datashape/coretypes.py
+++ b/datashape/coretypes.py
@@ -981,10 +981,7 @@ class Record(Mono):
         return self.dict[key]
 
     def __str__(self):
-        return record_string(self.names, self.types)
-
-    def __repr__(self):
-        return ''.join(["dshape(\"", str(self).encode('unicode_escape').decode('ascii'), "\")"])
+        return pprint(self)
 
 
 class Tuple(Mono):

--- a/datashape/coretypes.py
+++ b/datashape/coretypes.py
@@ -606,16 +606,16 @@ class DataShape(Mono):
 
         >>> ds = dshape('var * {name: string, amount: int32}')
         >>> print(ds.subshape[0])
-        { name : string, amount : int32 }
+        {name: string, amount: int32}
 
         >>> print(ds.subshape[0:3])
-        3 * { name : string, amount : int32 }
+        3 * {name: string, amount: int32}
 
         >>> print(ds.subshape[0:7:2, 'amount'])
         4 * int32
 
         >>> print(ds.subshape[[1, 10, 15]])
-        3 * { name : string, amount : int32 }
+        3 * {name: string, amount: int32}
 
         >>> ds = dshape('{x: int, y: int}')
         >>> print(ds.subshape['x'])
@@ -627,14 +627,14 @@ class DataShape(Mono):
 
         >>> ds = dshape('var * {name: string, amount: int32, id: int32}')
         >>> print(ds.subshape[:, [0, 2]])
-        var * { name : string, id : int32 }
+        var * {name: string, id: int32}
 
         >>> ds = dshape('var * {name: string, amount: int32, id: int32}')
         >>> print(ds.subshape[:, ['name', 'id']])
-        var * { name : string, id : int32 }
+        var * {name: string, id: int32}
 
         >>> print(ds.subshape[0, 1:])
-        { amount : int32, id : int32 }
+        {amount: int32, id: int32}
         """
         from .predicates import isdimension
         if isinstance(index, _inttypes) and isdimension(self[0]):
@@ -936,7 +936,7 @@ class Record(Mono):
     -------
 
     >>> Record([['id', 'int'], ['name', 'string'], ['amount', 'real']])
-    dshape("{ id : int32, name : string, amount : float64 }")
+    dshape("{id: int32, name: string, amount: float64}")
     """
     cls = MEASURE
 

--- a/datashape/tests/test_coretypes.py
+++ b/datashape/tests/test_coretypes.py
@@ -2,7 +2,6 @@ import pickle
 
 import numpy as np
 import pytest
-import unittest
 
 from datashape.coretypes import (Record, real, String, CType, DataShape, int32,
                                  Fixed, Option, _units, _unit_aliases)
@@ -33,7 +32,8 @@ def test_integers():
 
 
 def test_error_on_datashape_with_string_argument():
-    assert pytest.raises(TypeError, lambda : DataShape('5 * int32'))
+    with pytest.raises(TypeError):
+        DataShape('5 * int32')
 
 
 class TestToNumpyDtype(object):
@@ -163,16 +163,19 @@ def test_option_sanitizes_strings():
 
 class TestComplexFieldNames(object):
     """
-    The tests in this class should verify that the datashape parser can handle field names that contain
-      strange characters like spaces, quotes, and backslashes
-    The idea is that any given input datashape should be recoverable once we have created the actual dshape object.
+    The tests in this class should verify that the datashape parser can handle
+    field names that contain strange characters like spaces, quotes, and
+    backslashes
 
-    This test suite is by no means complete, but it does handle some of the more common special cases (common special? oxymoron?)
+    The idea is that any given input datashape should be recoverable once we
+    have created the actual dshape object.
+
+    This test suite is by no means complete, but it does handle some of the
+    more common special cases (common special? oxymoron?)
     """
     def test_spaces_01(self):
-        space_dshape="""{ 'Unique Key' : ?int64 }"""
-        ds1=dshape(space_dshape)
-        assert space_dshape == str(ds1)
+        space_dshape = "{'Unique Key': ?int64}"
+        assert space_dshape == str(dshape(space_dshape))
 
     def test_spaces_02(self):
         big_space_dshape="""{ 'Unique Key' : ?int64, 'Created Date' : string,
@@ -198,46 +201,45 @@ Borough : string, 'X Coordinate (State Plane)' : ?int64,
 'Ferry Direction' : string, 'Ferry Terminal Name' : string,
 Latitude : ?float64, Longitude : ?float64, Location : string }"""
 
-
-        ds1=dshape(big_space_dshape)
-        ds2=dshape(str(ds1))
+        ds1 = dshape(big_space_dshape)
+        ds2 = dshape(str(ds1))
 
         assert str(ds1) == str(ds2)
 
     def test_single_quotes_01(self):
 
-        quotes_dshape="""{ 'field \\' with \\' quotes' : string }"""
+        quotes_dshape = """{ 'field \\' with \\' quotes' : string }"""
 
-        ds1=dshape(quotes_dshape)
-        ds2=dshape(str(ds1))
+        ds1 = dshape(quotes_dshape)
+        ds2 = dshape(str(ds1))
 
         assert str(ds1) == str(ds2)
 
     def test_double_quotes_01(self):
-        quotes_dshape="""{ 'doublequote \" field \"' : int64 }"""
-        ds1=dshape(quotes_dshape)
-        ds2=dshape(str(ds1))
+        quotes_dshape = """{ 'doublequote \" field \"' : int64 }"""
+        ds1 = dshape(quotes_dshape)
+        ds2 = dshape(str(ds1))
 
         assert str(ds1) == str(ds2)
 
     def test_multi_quotes_01(self):
-        quotes_dshape="""{ 'field \\' with \\' quotes' : string, 'doublequote \" field \"' : int64 }"""
+        quotes_dshape = """{ 'field \\' with \\' quotes' : string, 'doublequote \" field \"' : int64 }"""
 
-        ds1=dshape(quotes_dshape)
-        ds2=dshape(str(ds1))
+        ds1 = dshape(quotes_dshape)
+        ds2 = dshape(str(ds1))
 
         assert str(ds1) == str(ds2)
 
     def test_mixed_quotes_01(self):
-        quotes_dshape="""{ 'field \" with \\' quotes' : string, 'doublequote \" field \\'' : int64 }"""
+        quotes_dshape = """{ 'field \" with \\' quotes' : string, 'doublequote \" field \\'' : int64 }"""
 
-        ds1=dshape(quotes_dshape)
-        ds2=dshape(str(ds1))
+        ds1 = dshape(quotes_dshape)
+        ds2 = dshape(str(ds1))
 
         assert str(ds1) == str(ds2)
 
     def test_bad_02(self):
-        bad_dshape="""{ Unique Key : int64}"""
+        bad_dshape = """{ Unique Key : int64}"""
         with pytest.raises(error.DataShapeSyntaxError):
             dshape(bad_dshape)
 
@@ -246,7 +248,7 @@ Latitude : ?float64, Longitude : ?float64, Location : string }"""
         in lexer.py as of 2014-10-02. This is probably an oversight that should
         be fixed.
         """
-        backslash_dshape="""{ 'field with \\\\   backslashes' : int64 }"""
+        backslash_dshape = """{ 'field with \\\\   backslashes' : int64 }"""
 
         with pytest.raises(error.DataShapeSyntaxError):
             dshape(backslash_dshape)

--- a/datashape/tests/test_creation.py
+++ b/datashape/tests/test_creation.py
@@ -197,4 +197,4 @@ class TestDataShapeCreation(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main()  # pragma: no cover

--- a/datashape/tests/test_creation.py
+++ b/datashape/tests/test_creation.py
@@ -96,7 +96,8 @@ class TestDataShapeCreation(unittest.TestCase):
         self.assertEqual(dshape('datetime[tz="UTC"]')[0].tz, 'UTC')
         self.assertEqual(dshape('datetime[tz="America/Vancouver"]')[0].tz,
                          'America/Vancouver')
-        self.assertEqual(str(dshape('datetime[tz="UTC"]')), "datetime[tz='UTC']")
+        self.assertEqual(str(dshape('datetime[tz="UTC"]')),
+                         "datetime[tz='UTC']")
 
     def test_units(self):
         self.assertEqual(dshape('units["second"]')[0].unit, 'second')
@@ -183,7 +184,8 @@ class TestDataShapeCreation(unittest.TestCase):
                'uintptr',
                '{id: int8, value: bool, result: int16}',
                '{a: int32, b: int64, x: uint8, y: uint16, z: uint32}',
-               '{a: float32, b: float64, c: complex64, d: complex128, e: string, f: json, g: date, h: time, i: datetime}']
+               '{a: float32, b: float64, c: complex64, d: complex128, '
+               ' e: string, f: json, g: date, h: time, i: datetime}']
 
     dimensions = ['2',
                   '100',

--- a/datashape/tests/test_creation.py
+++ b/datashape/tests/test_creation.py
@@ -111,12 +111,13 @@ class TestDataShapeCreation(unittest.TestCase):
     def test_struct_of_array(self):
         self.assertEqual(str(dshape('5 * int32')), '5 * int32')
         self.assertEqual(str(dshape('{field: 5 * int32}')),
-                         '{ field : 5 * int32 }')
+                         '{field: 5 * int32}')
         self.assertEqual(str(dshape('{field: M * int32}')),
-                         '{ field : M * int32 }')
+                         '{field: M * int32}')
 
     def test_ragged_array(self):
-        self.assertTrue(isinstance(dshape('3 * var * int32')[1], datashape.Var))
+        self.assertTrue(isinstance(dshape('3 * var * int32')[1],
+                        datashape.Var))
 
     def test_from_numpy_fields(self):
         import numpy as np

--- a/datashape/tests/test_creation.py
+++ b/datashape/tests/test_creation.py
@@ -68,6 +68,9 @@ class TestDataShapeCreation(unittest.TestCase):
     @xfail(reason='type decl has been removed in the new parser')
     def test_type_decl(self):
         self.assertRaises(error.DataShapeTypeError, dshape, 'type X T = 3, T')
+
+    @xfail(reason='type decl has been removed in the new parser')
+    def test_type_decl_concrete(self):
         self.assertEqual(dshape('3, int32'), dshape('type X = 3, int32'))
 
     def test_string_atom(self):

--- a/datashape/tests/test_discovery.py
+++ b/datashape/tests/test_discovery.py
@@ -48,9 +48,9 @@ def test_string():
 
 
 def test_record():
-    assert discover({'name': 'Alice', 'amount': 100}) == \
+    assert (discover({'name': 'Alice', 'amount': 100}) ==
             Record([['amount', discover(100)],
-                    ['name', discover('Alice')]])
+                    ['name', discover('Alice')]]))
 
 
 def test_datetime():
@@ -114,8 +114,8 @@ def test_integrative():
             {'name': 'Bob', 'amount': '200'},
             {'name': 'Charlie', 'amount': '300'}]
 
-    assert dshape(discover(data)) == \
-            dshape('3 * {amount: int64, name: string}')
+    assert (dshape(discover(data)) ==
+            dshape('3 * {amount: int64, name: string}'))
 
 
 def test_numpy_scalars():
@@ -134,7 +134,7 @@ def test_numpy_array_with_strings():
 
 def test_numpy_recarray_with_strings():
     x = np.array([('Alice', 1), ('Bob', 2)],
-            dtype=[('name', 'O'), ('amt', 'i4')])
+                 dtype=[('name', 'O'), ('amt', 'i4')])
     assert discover(x) == dshape('2 * {name: string, amt: int32}')
 
 
@@ -156,31 +156,31 @@ def test_unite_missing_values():
 
 
 def test_unite_tuples():
-    assert discover([[1, 1, 'hello'],
+    assert (discover([[1, 1, 'hello'],
                      [1, '', ''],
-                     [1, 1, 'hello']]) == \
-                    3 * Tuple([int64, Option(int64), Option(string)])
+                     [1, 1, 'hello']]) ==
+            3 * Tuple([int64, Option(int64), Option(string)]))
 
-    assert discover([[1, 1, 'hello', 1],
+    assert (discover([[1, 1, 'hello', 1],
                      [1, '', '', 1],
-                     [1, 1, 'hello', 1]]) == \
-                    3 * Tuple([int64, Option(int64), Option(string), int64])
+                     [1, 1, 'hello', 1]]) ==
+            3 * Tuple([int64, Option(int64), Option(string), int64]))
 
 
 def test_unite_records():
-    assert discover([{'name': 'Alice', 'balance': 100},
-                     {'name': 'Bob', 'balance': ''}]) == \
-                    2 * Record([['balance', Option(int64)], ['name', string]])
+    assert (discover([{'name': 'Alice', 'balance': 100},
+                     {'name': 'Bob', 'balance': ''}]) ==
+            2 * Record([['balance', Option(int64)], ['name', string]]))
 
-    assert discover([{'name': 'Alice', 's': 'foo'},
-                     {'name': 'Bob', 's': None}]) == \
-                    2 * Record([['name', string], ['s', Option(string)]])
+    assert (discover([{'name': 'Alice', 's': 'foo'},
+                     {'name': 'Bob', 's': None}]) ==
+            2 * Record([['name', string], ['s', Option(string)]]))
 
-    assert discover([{'name': 'Alice', 's': 'foo', 'f': 1.0},
-                     {'name': 'Bob', 's': None, 'f': None}]) == \
-                    2 * Record([['f', Option(float64)],
-                                ['name', string],
-                                ['s', Option(string)]])
+    assert (discover([{'name': 'Alice', 's': 'foo', 'f': 1.0},
+                     {'name': 'Bob', 's': None, 'f': None}]) ==
+            2 * Record([['f', Option(float64)],
+                        ['name', string],
+                        ['s', Option(string)]]))
 
     # assert unite((Record([['name', string], ['balance', int32]]),
     #               Record([['name', string]]))) == \
@@ -188,31 +188,30 @@ def test_unite_records():
 
 
 def test_dshape_missing_data():
-    assert discover([[1, 2, '', 3],
+    assert (discover([[1, 2, '', 3],
                      [1, 2, '', 3],
-                     [1, 2, '', 3]]) == \
-                3 * Tuple([int64, int64, null, int64])
+                     [1, 2, '', 3]]) ==
+            3 * Tuple([int64, int64, null, int64]))
 
 
 def test_discover_mixed():
     i = discover(1)
     f = discover(1.0)
-    assert dshape(discover([[1, 2, 1.0, 2.0]] * 10)) == \
-            10 * Tuple([i, i, f, f])
+    exp = 10 * Tuple([i, i, f, f])
+    assert dshape(discover([[1, 2, 1.0, 2.0]] * 10)) == exp
 
-    assert dshape(discover([[1, 2, 1.0, 2.0], [1.0, 2.0, 1, 2]] * 5)) == \
-            10 * (4 * f)
+    exp = 10 * (4 * f)
+    assert dshape(discover([[1, 2, 1.0, 2.0], [1.0, 2.0, 1, 2]] * 5)) == exp
 
 
 def test_test():
-    assert discover([['Alice', 100], ['Bob', 200]]) == \
-            2 * Tuple([string, int64])
+    expected = 2 * Tuple([string, int64])
+    assert discover([['Alice', 100], ['Bob', 200]]) == expected
 
 
 def test_discover_appropriate():
     assert discover((1, 1.0)) == Tuple([int64, real])
-    assert discover([(1, 1.0), (1, 1.0), (1, 1)]) == \
-            3 * Tuple([int64, real])
+    assert discover([(1, 1.0), (1, 1.0), (1, 1)]) == 3 * Tuple([int64, real])
 
 
 def test_big_discover():
@@ -244,14 +243,11 @@ def test_list_of_dicts_difference():
 def test_unite_base_on_records():
     dshapes = [dshape('{name: string, amount: int32}'),
                dshape('{name: string, amount: int32}')]
-    assert unite_base(dshapes) == \
-            dshape('2 * {name: string, amount: int32}')
+    assert unite_base(dshapes) == dshape('2 * {name: string, amount: int32}')
 
     dshapes = [Null(), dshape('{name: string, amount: int32}')]
-    assert unite_base(dshapes) == \
-            dshape('2 * ?{name: string, amount: int32}')
+    assert unite_base(dshapes) == dshape('2 * ?{name: string, amount: int32}')
 
     dshapes = [dshape('{name: string, amount: int32}'),
                dshape('{name: string, amount: int64}')]
-    assert unite_base(dshapes) == \
-            dshape('2 * {name: string, amount: int64}')
+    assert unite_base(dshapes) == dshape('2 * {name: string, amount: int64}')

--- a/datashape/tests/test_discovery.py
+++ b/datashape/tests/test_discovery.py
@@ -28,7 +28,6 @@ def test_long():
 
 
 def test_list():
-    print(discover([1, 2, 3]))
     assert discover([1, 2, 3]) == 3 * discover(1)
     assert discover([1.0, 2.0, 3.0]) == 3 * discover(1.0)
 
@@ -38,7 +37,6 @@ def test_set():
 
 
 def test_heterogeneous_ordered_container():
-    print(discover(('Hello', 1)))
     assert discover(('Hello', 1)) == Tuple([discover('Hello'), discover(1)])
 
 
@@ -202,21 +200,17 @@ def test_discover_mixed():
     assert dshape(discover([[1, 2, 1.0, 2.0]] * 10)) == \
             10 * Tuple([i, i, f, f])
 
-    print(dshape(discover([[1, 2, 1.0, 2.0], [1.0, 2.0, 1, 2]] * 5)))
     assert dshape(discover([[1, 2, 1.0, 2.0], [1.0, 2.0, 1, 2]] * 5)) == \
             10 * (4 * f)
 
 
 def test_test():
-    print(discover([['Alice', 100], ['Bob', 200]]))
-    print(2 * Tuple([string, int64]))
     assert discover([['Alice', 100], ['Bob', 200]]) == \
             2 * Tuple([string, int64])
 
 
 def test_discover_appropriate():
     assert discover((1, 1.0)) == Tuple([int64, real])
-    print(discover([(1, 1.0), (1, 1.0), (1, 1)]))
     assert discover([(1, 1.0), (1, 1.0), (1, 1)]) == \
             3 * Tuple([int64, real])
 

--- a/datashape/tests/test_discovery.py
+++ b/datashape/tests/test_discovery.py
@@ -251,3 +251,10 @@ def test_unite_base_on_records():
     dshapes = [dshape('{name: string, amount: int32}'),
                dshape('{name: string, amount: int64}')]
     assert unite_base(dshapes) == dshape('2 * {name: string, amount: int64}')
+
+
+def test_nested_complex_record_type():
+    dt = np.dtype([('a', 'U7'), ('b', [('c', 'int64', 2), ('d', 'float64')])])
+    x = np.zeros(5, dt)
+    s = "5 * {a: string[7, 'U32'], b: {c: 2 * int64, d: float64}}"
+    assert discover(x) == dshape(s)

--- a/datashape/tests/test_str.py
+++ b/datashape/tests/test_str.py
@@ -26,7 +26,7 @@ class TestDataShapeStr(unittest.TestCase):
 
     def test_array_str(self):
         self.assertEqual(str(dshape('3*5*int16')),
-                        '3 * 5 * int16')
+                         '3 * 5 * int16')
 
     def test_primitive_measure_repr(self):
         self.assertEqual(repr(datashape.int8),      'ctype("int8")')
@@ -42,15 +42,15 @@ class TestDataShapeStr(unittest.TestCase):
         self.assertEqual(repr(datashape.string),    'ctype("string")')
         self.assertEqual(repr(datashape.String(3)), 'ctype("string[3]")')
         self.assertEqual(repr(datashape.String('A')),
-                        'ctype("string[\'A\']")')
+                         """ctype("string['A']")""")
 
     def test_structure_repr(self):
         self.assertEqual(repr(dshape('{x:int32, y:int64}')),
-                        'dshape("{x: int32, y: int64}")')
+                         'dshape("{x: int32, y: int64}")')
 
     def test_array_repr(self):
         self.assertEqual(repr(dshape('3*5*int16')),
-                        'dshape("3 * 5 * int16")')
+                         'dshape("3 * 5 * int16")')
 
 
 if __name__ == '__main__':

--- a/datashape/tests/test_str.py
+++ b/datashape/tests/test_str.py
@@ -54,5 +54,4 @@ class TestDataShapeStr(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
-
+    unittest.main()  # pragma: no cover

--- a/datashape/tests/test_str.py
+++ b/datashape/tests/test_str.py
@@ -22,7 +22,7 @@ class TestDataShapeStr(unittest.TestCase):
 
     def test_structure_str(self):
         self.assertEqual(str(dshape('{x:int32, y:int64}')),
-                        '{ x : int32, y : int64 }')
+                         '{x: int32, y: int64}')
 
     def test_array_str(self):
         self.assertEqual(str(dshape('3*5*int16')),


### PR DESCRIPTION
* record dshape now prints using pprint
* discover now works for nested dtype numpy arrays
* removes some functions that are not used