### PR TITLE
Implement to_numpy_dtype on Option types for date, datetime, and timedelta types

### DIFF
--- a/datashape/coretypes.py
+++ b/datashape/coretypes.py
@@ -704,6 +704,9 @@ class DataShape(Mono):
         self.__init__(*state)
 
 
+numpy_provides_missing = frozenset((Date, DateTime, TimeDelta))
+
+
 class Option(Mono):
     """
     Measure types which may or may not hold data. Makes no
@@ -726,6 +729,12 @@ class Option(Mono):
         return '?%s' % str(self.ty)
 
     __repr__ = __str__
+
+    def to_numpy_dtype(self):
+        if type(self.ty) in numpy_provides_missing:
+            return self.ty.to_numpy_dtype()
+        raise NotNumpyCompatible('DataShape measure %s is not '
+                                 'NumPy-compatible' % self)
 
 
 class CType(Unit):

--- a/datashape/tests/test_coretypes.py
+++ b/datashape/tests/test_coretypes.py
@@ -4,7 +4,8 @@ import numpy as np
 import pytest
 
 from datashape.coretypes import (Record, real, String, CType, DataShape, int32,
-                                 Fixed, Option, _units, _unit_aliases)
+                                 Fixed, Option, _units, _unit_aliases, Date,
+                                 DateTime, TimeDelta)
 from datashape import dshape, to_numpy_dtype, from_numpy, error
 from datashape.py2help import unicode
 
@@ -280,3 +281,18 @@ def test_record_with_unicode_name_as_numpy_dtype():
 def test_tuple_datashape_to_numpy_dtype():
     ds = dshape('5 * (int32, float32)')
     assert to_numpy_dtype(ds) == [('f0', 'i4'), ('f1', 'f4')]
+
+
+def test_option_date_to_numpy():
+    assert Option(Date()).to_numpy_dtype() == np.dtype('datetime64[D]')
+
+
+def test_option_datetime_to_numpy():
+    assert Option(DateTime()).to_numpy_dtype() == np.dtype('datetime64[us]')
+
+
+@pytest.mark.parametrize('unit',
+                         ['Y', 'M', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'])
+def test_option_timedelta_to_numpy(unit):
+    assert (Option(TimeDelta(unit=unit)).to_numpy_dtype() ==
+            np.dtype('timedelta64[%s]' % unit))


### PR DESCRIPTION
closes #144 