### PR TITLE
fix setup package url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description='A data description language.',
     license='BSD',
     keywords='data language',
-    url='http://packages.python.org/datashape',
+    url='http://datashape.readthedocs.org/en/latest/',
     packages=['datashape', 'datashape.tests'],
     install_requires=read('requirements.txt').strip().split('\n'),
     long_description=read('README.rst'),


### PR DESCRIPTION
Old link broken: http://packages.python.org/datashape 

Changed for readthedocs link: http://datashape.readthedocs.org/en/latest/